### PR TITLE
Allow the HTTPD server to work in a proxy mode. If you define a custo…

### DIFF
--- a/src/android/CorHttpd.java
+++ b/src/android/CorHttpd.java
@@ -160,7 +160,7 @@ public class CorHttpd extends CordovaPlugin {
                     while (keys.hasNext()) {
                         String key = (String) keys.next();
                         String path = jsonCustomPaths.optString(key);
-                        if (!path.startsWith("/")) {
+                        if (!path.startsWith("/") && !path.startsWith("http://") && !path.startsWith("https://")) {
                             if (path.length() > 0) {
                                 path = "www/" + path;
                             } else {
@@ -168,9 +168,13 @@ public class CorHttpd extends CordovaPlugin {
                             }
                         }
                         Log.w(LOGTAG, "Custom URL - " + key + " - " + path);
-                        AndroidFile p = new AndroidFile(path);
-                        p.setAssetManager( am );
-                        customPaths.put(key, p);
+                        if (path.startsWith("http://") || path.startsWith("https://" )) {
+                            customPaths.put(key, path);
+                        } else {
+                            AndroidFile p = new AndroidFile(path);
+                            p.setAssetManager(am);
+                            customPaths.put(key, p);
+                        }
                     }
                 }
             }

--- a/src/android/NanoHTTPD.java
+++ b/src/android/NanoHTTPD.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.lang.InterruptedException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -832,15 +833,18 @@ public class NanoHTTPD
 
 				if ( data != null )
 				{
-					int pending = data.available();	// This is to support partial sends, see serveFile()
 					byte[] buff = new byte[theBufferSize];
-					while (pending>0)
+                    int read;
+					while ((read = data.read( buff, 0, theBufferSize)) != -1 )
 					{
-						int read = data.read( buff, 0, ( (pending>theBufferSize) ?  theBufferSize : pending ));
-						if (read <= 0)	break;
-						out.write( buff, 0, read );
-						pending -= read;
-					}
+                        if (read == 0) {
+                            try {
+                                Thread.sleep(50);
+                            } catch (InterruptedException e) {}
+                        } else {
+                            out.write(buff, 0, read);
+                        }
+                    }
 				}
 				out.flush();
 				out.close();

--- a/src/android/WebServer.java
+++ b/src/android/WebServer.java
@@ -1,11 +1,18 @@
 package com.rjfun.cordova.httpd;
 
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.io.IOException;
+import java.lang.Override;
 import java.lang.String;
+import java.net.MalformedURLException;
 import java.net.InetSocketAddress;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+
 
 import android.util.Log;
 
@@ -40,14 +47,112 @@ public class WebServer extends NanoHTTPD
     
     public Response serve( String uri, String method, Properties header, Properties parms, Properties files )
     {
+        if (uri == null || method == null) {
+            return null;
+        }
+        Log.i( LOGTAG, method + " '" + uri + "' " );
         for (int i = 0; i < customURIs.length; i++) {
             String testURI = customURIs[i];
             if (uri.startsWith(testURI)) {
                 Log.i( LOGTAG, method + " '" + uri + "' " );
                 String newURI = uri.substring(testURI.length());
-                return serveFile( newURI, header, (AndroidFile) customPaths.get(testURI), true );
+                Object customPath = customPaths.get(testURI);
+                if (customPath instanceof String) {
+                    URL url = null;
+                    HttpURLConnection connection = null;
+                    InputStream in = null;
+
+                    // Open the HTTP connection
+                    try {
+                        url = new URL(((String) customPath) + newURI);
+                        connection = (HttpURLConnection) url.openConnection();
+                        connection.connect();
+                    } catch (MalformedURLException e) {
+                        e.printStackTrace();
+                        return null;
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    try {
+                        in = new InputStreamWithOverloadedClose(connection.getInputStream(), connection);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    String datatype = connection.getContentType(); //NanoHTTPD.MIME_DEFAULT_BINARY
+                    Response response = new NanoHTTPD.Response(NanoHTTPD.HTTP_OK, datatype, in);
+                    if (connection.getContentEncoding() != null)
+                        response.addHeader("Content-Encoding", connection.getContentEncoding());
+                    if (connection.getContentLength() != -1)
+                        response.addHeader("Content-Length", "" + connection.getContentLength());
+                    if (connection.getHeaderField("Date") != null)
+                        response.addHeader("Date", connection.getHeaderField("Date"));
+                    if (connection.getHeaderField("Last-Modified") != null)
+                        response.addHeader("Last-Modified", connection.getHeaderField("Last-Modified"));
+                    if (connection.getHeaderField("Cache-Control") != null)
+                        response.addHeader("Cache-Control", connection.getHeaderField("Cache-Control"));
+                    return response;
+                } else {
+                    return serveFile( newURI, header, (AndroidFile) customPath, true );
+                }
             }
         }
         return super.serve( uri, method, header, parms, files );
+    }
+    
+    public class InputStreamWithOverloadedClose extends InputStream {
+        protected InputStream is;
+        protected HttpURLConnection connection; 
+        
+        public InputStreamWithOverloadedClose(InputStream is, HttpURLConnection connection) {
+            super();
+            this.is = is;
+            this.connection = connection;
+        }
+
+        @Override
+        public int available() throws IOException {
+            return is.available();
+        }
+
+        @Override
+        public void close() throws IOException {
+            is.close();
+            connection.disconnect();
+        }
+
+        @Override
+        public void mark(int readlimit) {
+            is.mark(readlimit);
+        }
+
+        @Override
+        public boolean markSupported() {
+            return is.markSupported();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return is.read();
+        }
+
+        @Override
+        public int read(byte[] buffer) throws IOException {
+            return is.read(buffer);
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            return is.read(buffer, offset, length);
+        }
+
+        @Override
+        public synchronized void reset() throws IOException {
+            is.reset();
+        }
+
+        @Override
+        public long skip(long byteCount) throws IOException {
+            return is.skip(byteCount);
+        }
     }
 }

--- a/src/ios/CorHttpd.m
+++ b/src/ios/CorHttpd.m
@@ -158,7 +158,7 @@
              NSString* path = (NSString*) obj;
              NSString* localPath = nil;
              const char * docroot = [path UTF8String];
-             if(*docroot == '/') {
+             if(*docroot == '/' || [path hasPrefix:@"http://"] || [path hasPrefix:@"https://"]) {
                  localPath = path;
              } else {
                  NSString* basePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"www"];

--- a/src/ios/CustomPathHTTPConnection.h
+++ b/src/ios/CustomPathHTTPConnection.h
@@ -1,7 +1,17 @@
 #import "HTTPConnection.h"
+#import "HTTPDataResponse.h"
 
 @interface CustomPathHTTPConnection : HTTPConnection
 + (NSDictionary *) customPaths;
 + (void) setCustomPaths:(NSDictionary *) cusPaths;
 - (NSString *)filePathForURI:(NSString *)path allowDirectory:(BOOL)allowDirectory documentRoot:(NSString *) documentRoot;
+- (NSObject<HTTPResponse> *)httpResponseForMethod:(NSString *)method URI:(NSString *)path;
+@end
+
+@interface HTTPDataResponseWithHeaders : HTTPDataResponse
+{
+    NSDictionary * headers;
+}
+- (id)initWithDataAndHeaders:(NSData *)data httpHeaders:(NSDictionary *) httpHeaders;
+- (NSDictionary *)httpHeaders;
 @end


### PR DESCRIPTION
…m path pointing to http://... or https://... it will internally redirect the request to the remote server, and serve the response back to the user from the local server.

For example:

cordova.plugins.CorHttpd.startServer({
                    'www_root': '',
                    'port': 8080,
                    'localhost_only': false,
                    'custom_paths': {
                        '/imgur/': 'http://i.imgur.com/'
                    }
                }, function(){console.log("SUCCESS");}, function(){console.log("FAILURE");});

When you then fetch http://localhost:8080/imgur/TNZYux0.jpg, you will fetch the content from imgur, and serve it as if it came from your own domain.

The reason for doing this... CrossDomain issues on image content served from an off device domain, and not wanting to apply unrestricted CORS access to all domains.

NOTE:
On iOS, this will download the entire contents of the response into memory before sending it on to the calling client. On Android, this is chunked in up to 16kb segments. Someone with more iOS experience than myself can probably make the iOS side of this behave more efficiently.
